### PR TITLE
Implement __bool__ for diskcache.Cache to make it Truthy

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -2364,6 +2364,10 @@ class Cache:
         """Count of items in cache including expired items."""
         return self.reset('count')
 
+    def __bool__(self):
+        """Mark Cache objects as Truthy"""
+        return True
+
     def __getstate__(self):
         return (self.directory, self.timeout, type(self.disk))
 


### PR DESCRIPTION
Python first checks `__bool__` and then `__len__` to determine whether an object is Truthy. Given the fact that an empty cache returns 0 for the length, it breaks checks that rely on `if cache` instead of `if cache is not None` to detect whether it's initialized. This commit fixes the issue.